### PR TITLE
Editorial fixes in the procedure comparison table

### DIFF
--- a/srfi-151.html
+++ b/srfi-151.html
@@ -763,7 +763,7 @@ the same as in this SRFI.
 </td></tr><tr><td>Integer length</td><td><tt>integer-length</tt></td><td><tt>integer-length</tt></td><td><tt>integer-length</tt></td><td><tt>integer-length</tt></td><td><tt>bitwise-length</tt></td><td><tt>integer-length</tt>
 </td></tr><tr><td>Mask selects source of bits</td><td>---</td><td><tt><i>bitwise-merge</i></tt></td><td><tt><i>bitwise-merge</i></tt></td><td><tt>bitwise-if</tt>, <tt>bitwise-merge</tt></td><td><tt>bitwise-if</tt></td><td><tt>bitwise-if</tt>
 </td></tr><tr><td>Test single bit</td><td><tt>logbitp</tt></td><td><tt>bit-set?</tt></td><td><tt>bit-set?</tt></td><td><tt>logbit?</tt>, <tt>bit-set?</tt></td><td><tt><i>bitwise-bit-set?</i></tt></td><td><tt>bit-set?</tt>
-</td></tr><tr><td>See if any mask bits set</td><td><tt>logtest</tt></td><td><tt>any-bits-set?</tt></td><td><tt>any-bit-set?</tt></td><td><tt>logtest</tt>, <tt>any-bit-set?</tt></td><td>---</td><td><tt>any-bit-set</tt>
+</td></tr><tr><td>See if any mask bits set</td><td><tt>logtest</tt></td><td><tt>any-bits-set?</tt></td><td><tt>any-bit-set?</tt></td><td><tt>logtest</tt>, <tt>any-bits-set?</tt></td><td>---</td><td><tt>any-bit-set?</tt>
 </td></tr><tr><td>See if all mask bits set</td><td>---</td><td><tt>all-bits-set?</tt></td><td><tt>every-bit-set?</tt></td><td>---</td><td>---</td><td><tt>every-bit-set?</tt>
 </td></tr><tr><td>Replace single bit</td><td>---</td><td>---</td><td><tt>copy-bit</tt></td><td><tt>copy-bit</tt></td><td><tt><i>bitwise-copy-bit</i></tt></td><td><tt>copy-bit</tt>
 </td></tr><tr><td>Swap bits</td><td>---</td><td>---</td><td>---</td><td>---</td><td>---</td><td><tt>bit-swap</tt>


### PR DESCRIPTION
In "See if any mask bit set" row,
srfi-60's column: any-bit-set? -> any-bits-set?
This srfi column: any-bit-set  -> any-bit-set?  (was missing question mark)