### PR TITLE
Make Chicken Scheme implementation compatible with Chicken 5

### DIFF
--- a/srfi-151/chicken-test.scm
+++ b/srfi-151/chicken-test.scm
@@ -1,4 +1,4 @@
-(use numbers) (use srfi-151) (use test)
+(import (chicken bitwise)) (import srfi-151) (import test)
 (current-test-verbosity #f)
 (test-group "bitwise"
  (test-group "bitwise/basic"

--- a/srfi-151/srfi-151.scm
+++ b/srfi-151/srfi-151.scm
@@ -1,12 +1,13 @@
 ;;;; chicken implementation of SRFI 151
 (module srfi-151 ()
   (import scheme)
-  (import (only chicken include use case-lambda when))
+  (import (only (chicken base) include case-lambda when)
+          (only (chicken module) export))
 
   ;; Provides bitwise-not, bitwise-and, butwise-ior, bitwise-xor,
   ;; arithmetic-shift, integer-length.  The remaining
   ;; core function, bit-count, is provided in this file.
-  (use numbers)
+  (import (chicken bitwise))
 
   (export bitwise-not bitwise-and bitwise-ior bitwise-xor bitwise-eqv
           bitwise-nand bitwise-nor bitwise-andc1 bitwise-andc2


### PR DESCRIPTION
Hi,

I honestly don't really know much about this whole SRFI standardization process. I just found this SRFI very interesting and wanted to play around with using Chicken Scheme. Unfortunately, the provided implementation does not seem to work with Chicken 5 though this can be easily fixed using the changes proposed here. As I said, I am unfamiliar with SRFI standardization and don't know if you accept such compatibility changes after the SRFI has been finalized.

With the changes proposed here the `srfi-151/chicken-test.scm` test cases pass successfully with Chicken 5. Though one has to manually install `srfi-151.scm` as a module beforehand or add `(include "srfi-151.scm")` to `chicken-test.scm`. I am not sure how this was handled in Chicken 4. I am also unsure why `chicken-test.scm` is duplicated in the repository root, should that file be modified as well?

---

This PR performs the following changes:

* Fixed imports of chicken base functionality
* Replaced remove `use` procedure with `import`
* Changed imports of old `numbers` module to new `bitwise` module