### PR TITLE
Fix html problems

### DIFF
--- a/srfi-151.html
+++ b/srfi-151.html
@@ -88,10 +88,13 @@ See <a href="#Bitprocessingorder">"Bit processing order"</a> for details.
 
 <h2 id="Generaldesignprinciples">General design principles</h2>
 <ul><li>These operations interpret exact integers using two's-complement representation.
-</li></ul><ul><li>The associative bitwise ops are required to be n-ary. Programmers can reliably write <tt>bitwise-and</tt> with 3 arguments, for example.
-</li></ul><ul><li>The word <tt>or</tt> is never used by itself, only with modifiers: <tt>xor</tt>, <tt>ior</tt>, <tt>nor</tt>,
+</li>
+<li>The associative bitwise ops are required to be n-ary. Programmers can reliably write <tt>bitwise-and</tt> with 3 arguments, for example.
+</li>
+<li>The word <tt>or</tt> is never used by itself, only with modifiers: <tt>xor</tt>, <tt>ior</tt>, <tt>nor</tt>,
 <tt>orc1</tt>, or <tt>orc2</tt>.  This is the same rule as Common Lisp.
-</li></ul><ul><li>Extra and redundant functions such as <tt>bitwise-count</tt>, <tt>bitwise-nor</tt> 
+</li>
+<li>Extra and redundant functions such as <tt>bitwise-count</tt>, <tt>bitwise-nor</tt>
 and the bit-field ops have been included.  Settling on a standard
 choice of names makes it easier to read
 code that uses these sorts of operations. It also means computations
@@ -100,12 +103,15 @@ synthesized with a snarled mess of <tt>bitwise-and</tt>s, <tt>bitwise-or</tt>s, 
 What we gain is having an agreed-upon set of names by which we can refer
 to these functions. If you believe in "small is beautiful," then what is your motivation
 for including anything beyond <tt>bitwise-nand</tt>?
-</li></ul><ul><li>Programmers don't have to re-implement the redundant functions, and stumble
+</li>
+<li>Programmers don't have to re-implement the redundant functions, and stumble
 over the boundary cases and error checking, but can express
 themselves using a full palette of building blocks.
-</li></ul><ul><li>Compilers can directly implement many of these ops for great efficiency gains
+</li>
+<li>Compilers can directly implement many of these ops for great efficiency gains
 without requiring any tricky analysis.
-</li></ul><ul><li>Logical right or left shift operations are excluded 
+</li>
+<li>Logical right or left shift operations are excluded
 because they are not well defined on general integers; they are only defined
 on integers in some finite range. Remember that, in this library, integers
 are interpreted as semi-infinite bit strings that have only a finite
@@ -121,38 +127,34 @@ The core of this  design mirrors the structure of Common Lisp's pretty closely. 
 </p>
 <ul><li>"load" and "deposit" are the wrong verbs (e.g., Common Lisp's <tt>ldb</tt> and <tt>dpb</tt> ops),
 since they have nothing to do with the store.  
-</li></ul><p>
-    
-</p>
-<ul><li><tt>boole</tt> has been removed; it is not one with the Way of Scheme.  Boolean functions
+</li>
+<li><tt>boole</tt> has been removed; it is not one with the Way of Scheme.  Boolean functions
 are directly encoded in Scheme as first-class functions.
-</li></ul><p>
-    
-</p>
-<ul><li>The name choices are more in tune with Scheme conventions (hyphenation,
+</li>
+<li>The name choices are more in tune with Scheme conventions (hyphenation,
 using <tt>?</tt> to mark a predicate, etc.). Common Lisp's name choices were more
 historically motivated, for reasons of backward compatibility with
 Maclisp and Zetalisp.
-</li></ul><p>
-    
-</p>
-<ul><li>The prefix <tt>log</tt> has been changed to <tt>bitwise-</tt> (e.g, <tt>lognot</tt> to <tt>bitwise-not</tt>),
+</li>
+<li>The prefix <tt>log</tt> has been changed to <tt>bitwise-</tt> (e.g, <tt>lognot</tt> to <tt>bitwise-not</tt>),
 as the prefix <tt>bitwise-</tt> more accurately reflects what they do.
-</li></ul><p>
-    
-</p>
-<ul><li>The six trivial binary boolean ops that return constants, the left or right arguments,
+</li>
+<li>The six trivial binary boolean ops that return constants, the left or right arguments,
 and the <tt>bitwise-not</tt> of the left or right arguments, do not appear in this SRFI.
 </li></ul><h2 id="SRFI33">SRFI 33</h2>
 <p>
 This SRFI contains all the procedures of SRFI 33, and retains their original names with these exceptions:
 </p>
 <ul><li>The name <tt>bitwise-merge</tt> is replaced by <tt>bitwise-if</tt>, the name used in SRFI 60 and R6RS.
-</li></ul><ul><li>The name <tt>extract-bit-field</tt> (<tt>bit-field-extract</tt> in Olin's revisions) is replaced by <tt>bit-field</tt>, the name used in SRFI 60 and R6RS.
-</li></ul><ul><li>The names <tt>any-bits-set?</tt> and <tt>all-bits-set?</tt> are replaced by <tt>any-bit-set?</tt> and <tt>every-bit-set?</tt>, in accordance with Olin's revisions.
-</li></ul><ul><li>The name <tt>test-bit-field?</tt> has been renamed <tt>bit-field-any?</tt> and supplemented with
+</li>
+<li>The name <tt>extract-bit-field</tt> (<tt>bit-field-extract</tt> in Olin's revisions) is replaced by <tt>bit-field</tt>, the name used in SRFI 60 and R6RS.
+</li>
+<li>The names <tt>any-bits-set?</tt> and <tt>all-bits-set?</tt> are replaced by <tt>any-bit-set?</tt> and <tt>every-bit-set?</tt>, in accordance with Olin's revisions.
+</li>
+<li>The name <tt>test-bit-field?</tt> has been renamed <tt>bit-field-any?</tt> and supplemented with
 <tt>bit-field-every?</tt>, in accordance with Olin's revisions.
-</li></ul><ul><li>Because  <tt>copy-bit-field</tt> means different things in SRFI 33 and SRFI 60,
+</li>
+<li>Because  <tt>copy-bit-field</tt> means different things in SRFI 33 and SRFI 60,
 SRFI 33's name <tt>copy-bit-field</tt> (<tt>bit-field-copy</tt> in Olin's revisions)
 has been changed to <tt>bit-field-replace-same</tt>.
 </li></ul><h2 id="SRFI60">SRFI 60</h2>
@@ -160,11 +162,14 @@ has been changed to <tt>bit-field-replace-same</tt>.
 SRFI 60 includes six procedures that do not have SRFI 33 equivalents.  They are incorporated into this SRFI as follows:
 </p>
 <ul><li>The names <tt>rotate-bit-field</tt> and <tt>reverse-bit-field</tt> are replaced by <tt>bit-field-rotate</tt> and <tt>bit-field-reverse</tt>, by analogy with Olin's revisions.
-</li></ul><ul><li>The procedure <tt>copy-bit</tt> is incorporated into this SRFI with the same name.
-</li></ul><ul><li>The procedures <tt>integer-&gt;list</tt> and <tt>list-&gt;integer</tt>
+</li>
+<li>The procedure <tt>copy-bit</tt> is incorporated into this SRFI with the same name.
+</li>
+<li>The procedures <tt>integer-&gt;list</tt> and <tt>list-&gt;integer</tt>
 are incorporated into this SRFI with the slightly different names <tt>integer-&gt;bits</tt>
 and <tt>bits-&gt;integer</tt> because they are incompatible with SRFI 60.
-</li></ul><ul><li>The procedure <tt>booleans-&gt;integer</tt> is a convenient way to specify a bitwise integer: it accepts an arbitrary number of boolean arguments and returns a non-negative integer.  So in this SRFI it has the short name <tt>bits</tt>, roughly analogous to <tt>list</tt>, <tt>string</tt>, and <tt>vector</tt>.
+</li>
+<li>The procedure <tt>booleans-&gt;integer</tt> is a convenient way to specify a bitwise integer: it accepts an arbitrary number of boolean arguments and returns a non-negative integer.  So in this SRFI it has the short name <tt>bits</tt>, roughly analogous to <tt>list</tt>, <tt>string</tt>, and <tt>vector</tt>.
 </li></ul><h2 id="Othersources">Other sources</h2>
 <ul><li><p>The following procedures are inspired by
 <a href="https://srfi.schemers.org/srfi-133/srfi-133.html">SRFI 133</a>:
@@ -175,20 +180,23 @@ and <tt>bits-&gt;integer</tt> because they are incompatible with SRFI 60.
 <li><p>The <tt>make-bitwise-generator</tt> procedure is a generator constructor similar to those
 provided by <a href="https://srfi.schemers.org/srfi/srfi-127.html">SRFI 127</a>.</p></li>
 </ul><h2 id="Argumentorderingandsemantics">Argument ordering and semantics</h2>
-<ul><li>In general, these procedures place the bitstring arguments to be operated on first.
+<p>In general, these procedures place the bitstring arguments to be operated on first.
 Where the operation is not commutative, the "destination" argument that provides
 the background bits to be operated on is placed before the "source" argument that provides
 the bits to be transferred to it.
-</li></ul><ul><li>In SRFI 33, <tt>bitwise-nand</tt> and <tt>bitwise-nor</tt> accepted an arbitrary number of arguments
+</p>
+<ul><li>In SRFI 33, <tt>bitwise-nand</tt> and <tt>bitwise-nor</tt> accepted an arbitrary number of arguments
 even though they are not commutative.  Olin's late revisions made them dyadic, and so
 does this SRFI.
-</li></ul><ul><li>Common Lisp bit-field operations use a <em>byte spec</em> to encapsulate the position and
+</li>
+<li>Common Lisp bit-field operations use a <em>byte spec</em> to encapsulate the position and
 size of the field.  SRFI 33 bit-field operations had leading <em>position</em> and <em>size</em>
 arguments instead.  These
 have been replaced in this SRFI by trailing <em>start</em> (inclusive) and <em>end</em> (exclusive)
 arguments, the convention used not only in SRFI 60 and R6RS but also in most other
 subsequence operations in Scheme standards and SRFIs.
-</li></ul><ul><li>In SRFI 60, the <tt>bitwise-if</tt> function was defined
+</li>
+<li>In SRFI 60, the <tt>bitwise-if</tt> function was defined
 with a different argument ordering from SRFI 33's <tt>bitwise-merge</tt>, but was provided
 under both names, using the SLIB ordering.  SRFI 142 adopted the SRFI 33 ordering rather
 than the SLIB and R6RS ordering.  Since SLIB and R6RS have seen far more usage than

--- a/srfi-151.html
+++ b/srfi-151.html
@@ -82,6 +82,7 @@ SLIB, SRFI 60, and R6RS rather than the ordering of SRFI 33.</p></li>
 and some of the procedures' names have been changed.
 See <a href="#Bitprocessingorder">"Bit processing order"</a> for details.
 </p></li></ol>
+</p>
 
 <h1>Rationale</h1>
 

--- a/srfi-151.html
+++ b/srfi-151.html
@@ -33,7 +33,7 @@ John Cowan
     <ul>
       <li>2017-07-25 (Fixed examples under <code>bit-field-any?</code> and <code>bit-field-every?</code>.  Removed obsolete test.)</li>
       <li>2017-10-18 (Fixed small errors in comparison table, which is in a non-normative section.)</li>
-      <li>2019-04-06 (Italicize <code>integer->list</code>, <code>list->integer</code>, and <code>booleans->integer</code> to reflect the changes made in SRFI 151 from SRFI 142.)</li>
+      <li>2019-04-06 (Italicize <code>integer-&gt;list</code>, <code>list-&gt;integer</code>, and <code>booleans-&gt;integer</code> to reflect the changes made in SRFI 151 from SRFI 142.)</li>
     </ul>
 </ul>
 
@@ -161,17 +161,17 @@ SRFI 60 includes six procedures that do not have SRFI 33 equivalents.  They are 
 </p>
 <ul><li>The names <tt>rotate-bit-field</tt> and <tt>reverse-bit-field</tt> are replaced by <tt>bit-field-rotate</tt> and <tt>bit-field-reverse</tt>, by analogy with Olin's revisions.
 </li></ul><ul><li>The procedure <tt>copy-bit</tt> is incorporated into this SRFI with the same name.
-</li></ul><ul><li>The procedures <tt>integer->list</tt> and <tt>list->integer</tt> 
-are incorporated into this SRFI with the slightly different names <tt>integer->bits</tt> 
-and <tt>bits->integer</tt> because they are incompatible with SRFI 60.
-</li></ul><ul><li>The procedure <tt>booleans->integer</tt> is a convenient way to specify a bitwise integer: it accepts an arbitrary number of boolean arguments and returns a non-negative integer.  So in this SRFI it has the short name <tt>bits</tt>, roughly analogous to <tt>list</tt>, <tt>string</tt>, and <tt>vector</tt>.
+</li></ul><ul><li>The procedures <tt>integer-&gt;list</tt> and <tt>list-&gt;integer</tt>
+are incorporated into this SRFI with the slightly different names <tt>integer-&gt;bits</tt>
+and <tt>bits-&gt;integer</tt> because they are incompatible with SRFI 60.
+</li></ul><ul><li>The procedure <tt>booleans-&gt;integer</tt> is a convenient way to specify a bitwise integer: it accepts an arbitrary number of boolean arguments and returns a non-negative integer.  So in this SRFI it has the short name <tt>bits</tt>, roughly analogous to <tt>list</tt>, <tt>string</tt>, and <tt>vector</tt>.
 </li></ul><h2 id="Othersources">Other sources</h2>
 <ul><li><p>The following procedures are inspired by
 <a href="https://srfi.schemers.org/srfi-133/srfi-133.html">SRFI 133</a>:
 <tt>bit-swap</tt>,
 <tt>bitwise-fold</tt>, <tt>bitwise-for-each</tt>, <tt>bitwise-unfold</tt>.  </p></li>
 <li><p>The procedure <tt>bit-field-set</tt> is the counterpart of <tt>bit-field-clear</tt>.</p></li>
-<li><p>The procedures <tt>bits->vector</tt> and <tt>vector->bits</tt> are inspired by their list counterparts.</p></li>
+<li><p>The procedures <tt>bits-&gt;vector</tt> and <tt>vector-&gt;bits</tt> are inspired by their list counterparts.</p></li>
 <li><p>The <tt>make-bitwise-generator</tt> procedure is a generator constructor similar to those
 provided by <a href="https://srfi.schemers.org/srfi/srfi-127.html">SRFI 127</a>.</p></li>
 </ul><h2 id="Argumentorderingandsemantics">Argument ordering and semantics</h2>
@@ -195,18 +195,18 @@ than the SLIB and R6RS ordering.  Since SLIB and R6RS have seen far more usage t
 SRFI 33, this SRFI adopts the SRFI 60 ordering instead.
 </li></ul>
 <h2 id="Bitprocessingorder">Bit processing order</h2>
-<p>In SLIB and SRFI 60, the the order in which bits were processed by <tt>integer->list</tt> and
-<tt>list->integer</tt> was not clearly specified.
+<p>In SLIB and SRFI 60, the the order in which bits were processed by <tt>integer-&gt;list</tt> and
+<tt>list-&gt;integer</tt> was not clearly specified.
 When SRFI 142 was written,
 the specification was clarified to process bits from least significant to most
-significant, so that <tt>(integer->list 6) => (#f #t #t)</tt>.  
+significant, so that <tt>(integer-&gt;list 6) =&gt; (#f #t #t)</tt>.
 However, the SLIB and SRFI 60 implementation
 processed them from the most significant bit to the least-significant bit,
-so that <tt>(integer->list 6) => (#t #t #f)</tt>.
+so that <tt>(integer-&gt;list 6) =&gt; (#t #t #f)</tt>.
 This SRFI retains the little-endian order,
-but renames the procedures to <tt>bits->list</tt> and <tt>list->bits</tt>
+but renames the procedures to <tt>bits-&gt;list</tt> and <tt>list-&gt;bits</tt>
 to avoid a silent breaking change from SLIB and SRFI 60.
-The same is true of the closely analogous <tt>integer->vector</tt>, <tt>vector->integer</tt>,
+The same is true of the closely analogous <tt>integer-&gt;vector</tt>, <tt>vector-&gt;integer</tt>,
 and <tt>bits</tt> procedures.
 </p>
 
@@ -232,7 +232,7 @@ bit-field-clear bit-field-set
 bit-field-replace  bit-field-replace-same
 bit-field-rotate bit-field-reverse
 
-bits->list list->bits bits->vector vector->bits
+bits-&gt;list list-&gt;bits bits-&gt;vector vector-&gt;bits
 bits
 bitwise-fold bitwise-for-each bitwise-unfold
 make-bitwise-generator
@@ -260,8 +260,8 @@ the next or 2<sup>1</sup> bit, and so forth.
 Returns the bitwise complement of <em>i</em>; that is, all 1 bits are changed
 to 0 bits and all 0 bits to 1 bits.
 </p>
-<pre>  (bitwise-not 10) => -11
-  (bitwise-not -37) => 36
+<pre>  (bitwise-not 10) =&gt; -11
+  (bitwise-not -37) =&gt; 36
 </pre><p>
 The following ten procedures correspond to the useful set
 of non-trivial two-argument boolean functions. For each such function,
@@ -294,11 +294,11 @@ everywhere that a, b and c all agree. That is, it does <em>not</em> produce
 Rather, it produces <tt>(bitwise-eqv a (bitwise-eqv b c))</tt> or the equivalent
 <tt>(bitwise-eqv (bitwise-eqv a b) c)</tt>.
 </p>
-<pre>      (bitwise-ior 3  10)     =>  11
-      (bitwise-and 11 26)     =>  10
-      (bitwise-xor 3 10)      =>   9
-      (bitwise-eqv 37 12)     => -42
-      (bitwise-and 37 12)     =>   4
+<pre>      (bitwise-ior 3  10)     =&gt;  11
+      (bitwise-and 11 26)     =&gt;  10
+      (bitwise-xor 3 10)      =&gt;   9
+      (bitwise-eqv 37 12)     =&gt; -42
+      (bitwise-and 37 12)     =&gt;   4
 </pre><p>
 <tt>(bitwise-nand </tt><em>i j</em><tt>)</tt><br />
 <tt>(bitwise-nor </tt><em>i j</em><tt>)</tt><br />
@@ -310,12 +310,12 @@ Rather, it produces <tt>(bitwise-eqv a (bitwise-eqv b c))</tt> or the equivalent
 <p>
 These operations are not associative.
 </p>
-<pre>      (bitwise-nand 11 26) =>  -11
-      (bitwise-nor  11 26) => -28
-      (bitwise-andc1 11 26) => 16
-      (bitwise-andc2 11 26) => 1
-      (bitwise-orc1 11 26) => -2
-      (bitwise-orc2 11 26) => -17
+<pre>      (bitwise-nand 11 26) =&gt;  -11
+      (bitwise-nor  11 26) =&gt; -28
+      (bitwise-andc1 11 26) =&gt; 16
+      (bitwise-andc2 11 26) =&gt; 1
+      (bitwise-orc1 11 26) =&gt; -2
+      (bitwise-orc2 11 26) =&gt; -17
 </pre><h2 id="Integeroperations">Integer operations</h2>
 <p>
 <tt>(arithmetic-shift </tt><em>i count</em><tt>)</tt>
@@ -323,10 +323,10 @@ These operations are not associative.
 <p>
 Returns the arithmetic left shift when <em>count</em>>0; right shift when <em>count</em>&lt;0.
 </p>
-<pre>    (arithmetic-shift 8 2) => 32
-    (arithmetic-shift 4 0) => 4
-    (arithmetic-shift 8 -1) => 4
-    (arithmetic-shift -100000000000000000000000000000000 -100) => -79
+<pre>    (arithmetic-shift 8 2) =&gt; 32
+    (arithmetic-shift 4 0) =&gt; 4
+    (arithmetic-shift 8 -1) =&gt; 4
+    (arithmetic-shift -100000000000000000000000000000000 -100) =&gt; -79
 </pre><p>
 <tt>(bit-count </tt><em>i</em><tt>)</tt>
 </p>
@@ -338,16 +338,16 @@ Compatibility note:  The R6RS analogue <tt>bitwise-bit-count</tt>
 applies <tt>bitwise-not</tt> to the population count before returning it
 if <i>i</i> is negative.
 </p>
-<pre>    (bit-count 0) =>  0
-    (bit-count -1) =>  0
-    (bit-count 7) =>  3
-    (bit-count  13) =>  3 ;Two's-complement binary: ...0001101
-    (bit-count -13) =>  2 ;Two's-complement binary: ...1110011
-    (bit-count  30) =>  4 ;Two's-complement binary: ...0011110
-    (bit-count -30) =>  4 ;Two's-complement binary: ...1100010
-    (bit-count (expt 2 100)) =>  1
-    (bit-count (- (expt 2 100))) =>  100
-    (bit-count (- (1+ (expt 2 100)))) =>  1
+<pre>    (bit-count 0) =&gt;  0
+    (bit-count -1) =&gt;  0
+    (bit-count 7) =&gt;  3
+    (bit-count  13) =&gt;  3 ;Two's-complement binary: ...0001101
+    (bit-count -13) =&gt;  2 ;Two's-complement binary: ...1110011
+    (bit-count  30) =&gt;  4 ;Two's-complement binary: ...0011110
+    (bit-count -30) =&gt;  4 ;Two's-complement binary: ...1100010
+    (bit-count (expt 2 100)) =&gt;  1
+    (bit-count (- (expt 2 100))) =&gt;  100
+    (bit-count (- (1+ (expt 2 100)))) =&gt;  1
 </pre><p>
 <tt>(integer-length </tt><em>i</em><tt>)</tt>
 </p>
@@ -368,13 +368,13 @@ to represent <em>i</em> in a signed twos-complement
 representation.
     
 </p>
-<pre>    (integer-length  0) => 0
-    (integer-length  1) => 1
-    (integer-length -1) => 0
-    (integer-length  7) => 3
-    (integer-length -7) => 3
-    (integer-length  8) => 4
-    (integer-length -8) => 3
+<pre>    (integer-length  0) =&gt; 0
+    (integer-length  1) =&gt; 1
+    (integer-length -1) =&gt; 0
+    (integer-length  7) =&gt; 3
+    (integer-length -7) =&gt; 3
+    (integer-length  8) =&gt; 4
+    (integer-length -8) =&gt; 3
 </pre><p>
 <tt>(bitwise-if </tt><em>mask i j</em><tt>)</tt>
 </p>
@@ -385,10 +385,10 @@ is 1, then the <em>k</em>th bit of the result is the <em>k</em>th bit of <em>i</
 the <em>k</em>th bit of <em>j</em>.  
 </p>
 <pre>
-    (bitwise-if 3 1 8) => 9
-    (bitwise-if 3 8 1) => 0
-    (bitwise-if 1 1 2) => 3
-    (bitwise-if #b00111100 #b11110000 #b00001111) => #b00110011
+    (bitwise-if 3 1 8) =&gt; 9
+    (bitwise-if 3 8 1) =&gt; 0
+    (bitwise-if 1 1 2) =&gt; 3
+    (bitwise-if #b00111100 #b11110000 #b00001111) =&gt; #b00110011
 </pre>
 <h2 id="Single-bitoperations">Single-bit operations</h2>
 <p>
@@ -403,12 +403,12 @@ integer)?
 </p>
 <p>Compatibility note: The R6RS analogue <tt>bitwise-bit-set?</tt>
 accepts its arguments in the opposite order.</p>
-<pre>    (bit-set? 1 1) =>  false
-    (bit-set? 0 1) =>  true
-    (bit-set? 3 10) =>  true
-    (bit-set? 1000000 -1) =>  true
-    (bit-set? 2 6) =>  true
-    (bit-set? 0 6) =>  false
+<pre>    (bit-set? 1 1) =&gt;  false
+    (bit-set? 0 1) =&gt;  true
+    (bit-set? 3 10) =&gt;  true
+    (bit-set? 1000000 -1) =&gt;  true
+    (bit-set? 2 6) =&gt;  true
+    (bit-set? 0 6) =&gt;  false
 </pre><p>
 <tt>(copy-bit </tt><em>index i boolean</em><tt>)</tt>
 </p>
@@ -428,9 +428,9 @@ However, an erratum made a silent breaking change to interpret the
 third argument as 0 for a false bit and 1 for a true bit.  Some
 R6RS implementations applied this erratum but others did not.
 </p>
-<pre>(copy-bit 0 0 #t) => #b1
-(copy-bit 2 0 #t) => #b100
-(copy-bit 2 #b1111 #f) => #b1011
+<pre>(copy-bit 0 0 #t) =&gt; #b1
+(copy-bit 2 0 #t) =&gt; #b100
+(copy-bit 2 #b1111 #f) =&gt; #b1011
 </pre><p>
 <tt>(bit-swap </tt><em>index<sub>1</sub> index<sub>2</sub> i</em><tt>)</tt>
 </p>
@@ -438,7 +438,7 @@ R6RS implementations applied this erratum but others did not.
 Returns an integer the same as <em>i</em> except that the <em>index<sub>1</sub></em>th bit
 and the <em>index<sub>2</sub></em>th bit have been exchanged.
 </p>
-<pre>(bit-swap 0 2 4) => #b1
+<pre>(bit-swap 0 2 4) =&gt; #b1
 </pre><p>
 <tt>(any-bit-set? </tt><em>test-bits i</em><tt>)</tt><br />
 <tt>(every-bit-set? </tt><em>test-bits i</em><tt>)</tt>
@@ -449,10 +449,10 @@ in bitstring <em>i</em>. I.e.,  returns <tt>(not (zero? (bitwise-and </tt><em>te
 and <tt>(= </tt><em>test-bits</em><tt> (bitwise-and</tt> <em>test-bits i</em>))) respectively.
 </p>
 <pre>
-    (any-bit-set? 3 6) => #t
-    (any-bit-set? 3 12) => #f
-    (every-bit-set? 4 6) => #t
-    (every-bit-set? 7 6) => #f
+    (any-bit-set? 3 6) =&gt; #t
+    (any-bit-set? 3 12) =&gt; #f
+    (every-bit-set? 4 6) =&gt; #t
+    (every-bit-set? 7 6) =&gt; #f
 </pre>
 <p>
 <tt>(first-set-bit </tt><em>i</em><tt>)</tt>
@@ -461,13 +461,13 @@ and <tt>(= </tt><em>test-bits</em><tt> (bitwise-and</tt> <em>test-bits i</em>)))
 Return the index of the first (smallest index) 1 bit in bitstring <em>i</em>.
 Return -1 if <em>i</em> contains no 1 bits (i.e., if <em>i</em> is zero).
 </p>
-<pre>    (first-set-bit 1) => 0
-    (first-set-bit 2) => 1
-    (first-set-bit 0) => -1
-    (first-set-bit 40) => 3
-    (first-set-bit -28) => 2
-    (first-set-bit (expt  2 99)) => 99
-    (first-set-bit (expt -2 99)) => 99
+<pre>    (first-set-bit 1) =&gt; 0
+    (first-set-bit 2) =&gt; 1
+    (first-set-bit 0) =&gt; -1
+    (first-set-bit 40) =&gt; 3
+    (first-set-bit -28) =&gt; 2
+    (first-set-bit (expt  2 99)) =&gt; 99
+    (first-set-bit (expt -2 99)) =&gt; 99
 </pre><h2 id="Bitfieldoperations">Bit field operations</h2>
 <p>
 These functions operate on a contiguous field of bits (a "byte," in
@@ -484,14 +484,14 @@ Returns the field from <em>i</em>, shifted
 down to the least-significant position in the result.
 </p>
 <pre>
-   (bit-field #b1101101010 0 4) => #b1010
-   (bit-field #b1101101010 3 9) => #b101101
-   (bit-field #b1101101010 4 9) => #b10110
-   (bit-field #b1101101010 4 10) => #b110110
-   (bit-field 6 0 1) => 0
-   (bit-field 6 1 3) => 3
-   (bit-field 6 2 999) => 1
-   (bit-field #x100000000000000000000000000000000 128 129) => 1
+   (bit-field #b1101101010 0 4) =&gt; #b1010
+   (bit-field #b1101101010 3 9) =&gt; #b101101
+   (bit-field #b1101101010 4 9) =&gt; #b10110
+   (bit-field #b1101101010 4 10) =&gt; #b110110
+   (bit-field 6 0 1) =&gt; 0
+   (bit-field 6 1 3) =&gt; 3
+   (bit-field 6 2 999) =&gt; 1
+   (bit-field #x100000000000000000000000000000000 128 129) =&gt; 1
 </pre>
 
 <p>
@@ -501,8 +501,8 @@ down to the least-significant position in the result.
 Returns true if any of the field's bits are set in bitstring <em>i</em>, and false otherwise.
 </p>
 <pre>
-  (bit-field-any? #b1001001 1 6) => #t
-  (bit-field-any? #b1000001 1 6) => #f
+  (bit-field-any? #b1001001 1 6) =&gt; #t
+  (bit-field-any? #b1000001 1 6) =&gt; #f
 </pre>
 
 <p>
@@ -512,8 +512,8 @@ Returns true if any of the field's bits are set in bitstring <em>i</em>, and fal
   Returns false if any of the field's bits are not set in bitstring <em>i</em>, and true otherwise.
 </p>
 <pre>
-  (bit-field-every? #b1011110 1 5) => #t
-  (bit-field-every? #b1011010 1 5) => #f
+  (bit-field-every? #b1011110 1 5) =&gt; #t
+  (bit-field-every? #b1011010 1 5) =&gt; #f
 </pre>
 <p>
 <tt>(bit-field-clear </tt><em>i start end</em><tt>)</tt><br />
@@ -523,8 +523,8 @@ Returns true if any of the field's bits are set in bitstring <em>i</em>, and fal
 Returns <em>i</em> with the field's bits set to all 0s/1s.
 </p>
 <pre>
-   (bit-field-clear #b101010 1 4) => #b100000
-   (bit-field-set #b101010 1 4) => #b101110
+   (bit-field-clear #b101010 1 4) =&gt; #b100000
+   (bit-field-set #b101010 1 4) =&gt; #b101110
 </pre>
 <p>
 <tt>(bit-field-replace </tt><em>dest source start end</em><tt>)</tt>
@@ -534,9 +534,9 @@ Returns <em>dest</em> with the field replaced
 by the least-significant <em>end-start</em> bits in <em>source</em>.
 </p>
 <pre>
-   (bit-field-replace #b101010 #b010 1 4) => #b100100
-   (bit-field-replace #b110 1 0 1) => #b111
-   (bit-field-replace #b110 1 1 2) => #b110
+   (bit-field-replace #b101010 #b010 1 4) =&gt; #b100100
+   (bit-field-replace #b110 1 0 1) =&gt; #b111
+   (bit-field-replace #b110 1 1 2) =&gt; #b110
 </pre>
 
 <p>
@@ -547,7 +547,7 @@ Returns <em>dest</em> with its field replaced
 by the corresponding field in <em>source</em>.
 </p>
 <pre>
-   (bit-field-replace-same #b1111 #b0000 1 3) => #b1001
+   (bit-field-replace-same #b1111 #b0000 1 3) =&gt; #b1001
 </pre>
 <p>
 <tt>(bit-field-rotate </tt><em>i count start end</em><tt>)</tt>
@@ -561,12 +561,12 @@ Compatibility note:  The R6RS analogue <tt>bitwise-rotate-bit-field</tt>
 uses the argument ordering <em>i start end count</em>.
 </p>
 <pre>
-   (bit-field-rotate #b110 0 0 10) => #b110
-   (bit-field-rotate #b110 0 0 256) => #b110
-   (bit-field-rotate #x100000000000000000000000000000000 1 0 129) => 1
-   (bit-field-rotate #b110 1 1 2) => #b110
-   (bit-field-rotate #b110 1 2 4) => #b1010
-   (bit-field-rotate #b0111 -1 1 4) => #b1011
+   (bit-field-rotate #b110 0 0 10) =&gt; #b110
+   (bit-field-rotate #b110 0 0 256) =&gt; #b110
+   (bit-field-rotate #x100000000000000000000000000000000 1 0 129) =&gt; 1
+   (bit-field-rotate #b110 1 1 2) =&gt; #b110
+   (bit-field-rotate #b110 1 2 4) =&gt; #b1010
+   (bit-field-rotate #b0111 -1 1 4) =&gt; #b1011
 </pre>
 
 <p>
@@ -576,18 +576,18 @@ uses the argument ordering <em>i start end count</em>.
 Returns <em>i</em> with the order of the bits in the field reversed.
 </p>
 <pre>
-   (bit-field-reverse 6 1 3) => 6
-   (bit-field-reverse 6 1 4) => 12
-   (bit-field-reverse 1 0 32) => #x80000000
-   (bit-field-reverse 1 0 31) => #x40000000
-   (bit-field-reverse 1 0 30) => #x20000000
-   (bit-field-reverse #x140000000000000000000000000000000 0 129) => 5
+   (bit-field-reverse 6 1 3) =&gt; 6
+   (bit-field-reverse 6 1 4) =&gt; 12
+   (bit-field-reverse 1 0 32) =&gt; #x80000000
+   (bit-field-reverse 1 0 31) =&gt; #x40000000
+   (bit-field-reverse 1 0 30) =&gt; #x20000000
+   (bit-field-reverse #x140000000000000000000000000000000 0 129) =&gt; 5
 </pre>
 
 <h2 id="Bitsconversion">Bits conversion</h2>
 <p>
-<tt>(bits->list </tt><em>i</em> [ <em>len</em> ]<tt>)</tt><br />
-<tt>(bits->vector </tt><em>i</em> [ <em>len</em> ]<tt>)</tt>
+<tt>(bits-&gt;list </tt><em>i</em> [ <em>len</em> ]<tt>)</tt><br />
+<tt>(bits-&gt;vector </tt><em>i</em> [ <em>len</em> ]<tt>)</tt>
 </p>
 <p>
 Returns a list/vector of <em>len</em> booleans corresponding to each bit of the non-negative integer <em>i</em>,
@@ -595,16 +595,15 @@ returning bit #0 as the first element, bit #1 as the second, and so on.
 <tt>#t</tt> is returned for each 1; <tt>#f</tt> for 0. 
 </p>
 <pre>
-   (bits->list #b1110101) => (#t #f #t #f #t #t #t)
-   (bits->list 3 5) => (#t #t #f #f #f)
-   (bits->list 6 4) => (#f #t #t #f)
+   (bits-&gt;list #b1110101) =&gt; (#t #f #t #f #t #t #t)
+   (bits-&gt;list 3 5) =&gt; (#t #t #f #f #f)
+   (bits-&gt;list 6 4) =&gt; (#f #t #t #f)
 
-   (bits->vector #b1110101) => #(#t #f #t #f #t #t #t)
+   (bits-&gt;vector #b1110101) =&gt; #(#t #f #t #f #t #t #t)
 </pre>
 
 <p>
-<tt>(list->bits </tt><em>list</em><tt>)</tt><br />
-<tt>(vector->bits </tt><em>vector</em><tt>)</tt>
+<tt>(list-&gt;bits </tt><em>list</em><tt>)</tt><br /> <tt>(vector-&gt;bits </tt><em>vector</em><tt>)</tt>
 </p>
 <p>
 Returns an integer formed from the booleans in <em>list/vector</em>,
@@ -614,23 +613,23 @@ A 1 bit is coded for each <tt>#t</tt>; a 0 bit for <tt>#f</tt>.
 Note that the result is never a negative integer.
 </p>
 <pre>
-   (list->bits '(#t #f #t #f #t #t #t)) => #b1110101
-   (list->bits '(#f #f #t #f #t #f #t #t #t)) => #b111010100
-   (list->bits '(#f #t #t)) => 6
-   (list->bits '(#f #t #t #f)) => 6
-   (list->bits '(#f #f #t #t)) => 12
+   (list-&gt;bits '(#t #f #t #f #t #t #t)) =&gt; #b1110101
+   (list-&gt;bits '(#f #f #t #f #t #f #t #t #t)) =&gt; #b111010100
+   (list-&gt;bits '(#f #t #t)) =&gt; 6
+   (list-&gt;bits '(#f #t #t #f)) =&gt; 6
+   (list-&gt;bits '(#f #f #t #t)) =&gt; 12
 
-   (vector->bits '#(#t #f #t #f #t #t #t)) => #b1110101
-   (vector->bits '#(#f #f #t #f #t #f #t #t #t)) => #b111010100
-   (vector->bits '#(#f #t #t)) => 6
-   (vector->bits '#(#f #t #t #f)) => 6
-   (vector->bits '#(#f #f #t #t)) => 12
+   (vector-&gt;bits '#(#t #f #t #f #t #t #t)) =&gt; #b1110101
+   (vector-&gt;bits '#(#f #f #t #f #t #f #t #t #t)) =&gt; #b111010100
+   (vector-&gt;bits '#(#f #t #t)) =&gt; 6
+   (vector-&gt;bits '#(#f #t #t #f)) =&gt; 6
+   (vector-&gt;bits '#(#f #f #t #t)) =&gt; 12
 </pre>
 
 <p>
 For positive integers,
-<tt>bits->list</tt> and <tt>list->bits</tt> are inverses in the sense of <tt>equal?</tt>,
-and so are <tt>bits->vector</tt> and <tt>vector->bits</tt>.
+<tt>bits-&gt;list</tt> and <tt>list-&gt;bits</tt> are inverses in the sense of <tt>equal?</tt>,
+and so are <tt>bits-&gt;vector</tt> and <tt>vector-&gt;bits</tt>.
 </p>
 <p>
 <tt>(bits </tt><em>bool</em> ...<tt>)</tt>
@@ -641,8 +640,8 @@ The first argument is bit #0, the second argument is bit #1, and so on.
 Note that the result is never a negative integer.
 </p>
 <pre>
-  (bits #t #f #t #f #t #t #t) => #b1110101
-  (bits #f #f #t #f #t #f #t #t #t) => #b111010100
+  (bits #t #f #t #f #t #t #t) =&gt; #b1110101
+  (bits #f #f #t #f #t #f #t #t #t) =&gt; #b111010100
 </pre>
 <h2 id="Foldunfoldandgenerate">Fold, unfold, and generate</h2>
 <p>
@@ -661,7 +660,7 @@ is <em>seed</em>, and the value returned by <em>proc</em> becomes the next accum
 the last bit has been processed, the final accumulated result becomes the result of <tt>bitwise-fold</tt>.
 </p>
 <pre>
-  (bitwise-fold cons '() #b1010111) => (#t #f #t #f #t #t #t)
+  (bitwise-fold cons '() #b1010111) =&gt; (#t #f #t #f #t #t #t)
 </pre>
 <p>
 <tt>(bitwise-for-each </tt><em>proc i</em><tt>)</tt>
@@ -695,7 +694,7 @@ the current state, and repeat this algorithm.
   (bitwise-unfold (lambda (i) (= i 10))
                   even?
                   (lambda (i) (+ i 1))
-                  0) => #b101010101
+                  0) =&gt; #b101010101
 </pre>
 <p>
 <tt>(make-bitwise-generator </tt><em>i</em><tt>)</tt>
@@ -781,11 +780,11 @@ the same as in this SRFI.
 </td></tr><tr><td>Replace corresponding bit field</td><td><tt><i>deposit-field</i></tt></td><td><tt><i>copy-bit-field</i></tt></td><td><tt><i>bit-field-copy</i></tt></td><td>---</td><td>---</td><td><tt>bit-field-replace-same</tt>
 </td></tr><tr><td>Rotate bit field</td><td>---</td><td>---</td><td>---</td><td><tt>rotate-bit-field</tt></td><td><tt><i>bitwise-rotate-bit-field</i></tt></td><td><tt>bit-field-rotate</tt>
 </td></tr><tr><td>Reverse bit field</td><td>---</td><td>---</td><td>---</td><td><tt>reverse-bit-field</tt></td><td><tt>bitwise-reverse-bit-field</tt></td><td><tt>bit-field-reverse</tt>
-</td></tr><tr><td>Bits to boolean list</td><td>---</td><td>---</td><td>---</td><td><tt><i>integer->list</i></tt></td><td>---</td><td><tt>bits->list</tt>
-</td></tr><tr><td>Bits to boolean vector</td><td>---</td><td>---</td><td>---</td><td>---</td><td>---</td><td><tt>bits->vector</tt>
-</td></tr><tr><td>Boolean list to bits</td><td>---</td><td>---</td><td>---</td><td><tt><i>list->integer</i></tt></td><td>---</td><td><tt>list->bits</tt>
-</td></tr><tr><td>Boolean vector to bits</td><td>---</td><td>---</td><td>---</td><td>---</td><td>---</td><td><tt>vector->bits</tt>
-</td></tr><tr><td>Booleans to integer</td><td>---</td><td>---</td><td>---</td><td><tt><i>booleans->integer</i></tt></td><td>---</td><td><tt>bits</tt>
+</td></tr><tr><td>Bits to boolean list</td><td>---</td><td>---</td><td>---</td><td><tt><i>integer-&gt;list</i></tt></td><td>---</td><td><tt>bits-&gt;list</tt>
+</td></tr><tr><td>Bits to boolean vector</td><td>---</td><td>---</td><td>---</td><td>---</td><td>---</td><td><tt>bits-&gt;vector</tt>
+</td></tr><tr><td>Boolean list to bits</td><td>---</td><td>---</td><td>---</td><td><tt><i>list-&gt;integer</i></tt></td><td>---</td><td><tt>list-&gt;bits</tt>
+</td></tr><tr><td>Boolean vector to bits</td><td>---</td><td>---</td><td>---</td><td>---</td><td>---</td><td><tt>vector-&gt;bits</tt>
+</td></tr><tr><td>Booleans to integer</td><td>---</td><td>---</td><td>---</td><td><tt><i>booleans-&gt;integer</i></tt></td><td>---</td><td><tt>bits</tt>
 </td></tr><tr><td>Bitwise fold</td><td>---</td><td>---</td><td>---</td><td>---</td><td>---</td><td><tt>bitwise-fold</tt>
 </td></tr><tr><td>Bitwise for-each</td><td>---</td><td>---</td><td>---</td><td>---</td><td>---</td><td><tt>bitwise-for-each</tt>
 </td></tr><tr><td>Bitwise unfold</td><td>---</td><td>---</td><td>---</td><td>---</td><td>---</td><td><tt>bitwise-unfold</tt>


### PR DESCRIPTION
This PR fixes or improves the HTML, to make it possible to parse the SRFI 151 HTML, which can be used to produce other document formats from it, e.g. Texinfo.