### PR TITLE
Comply with REUSE version 3.0 for licensing declaration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2015 Arthur A. Gleckler <srfi@speechcode.com>
+#
+# SPDX-License-Identifier: MIT
+
 *~

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,10 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: SRFI 151
+Upstream-Contact: Arthur A. Gleckler <srfi-editors@srfi.schemers.org>
+Source: https://github.com/scheme-requests-for-implementation/srfi-151
+
+# Sample paragraph, commented out:
+#
+# Files: src/*
+# Copyright: $YEAR $NAME <$CONTACT>
+# License: ...

--- a/LICENSES/LicenseRef-Public-Domain.txt
+++ b/LICENSES/LicenseRef-Public-Domain.txt
@@ -1,0 +1,2 @@
+Olin Shivers is the sole author of this code, and he has placed it in
+the public domain.

--- a/LICENSES/LicenseRef-SLIB.txt
+++ b/LICENSES/LicenseRef-SLIB.txt
@@ -1,0 +1,17 @@
+Copyright (C) 1991, 1993, 2001, 2003, 2005 Aubrey Jaffer
+
+Permission to copy this software, to modify it, to redistribute it,
+to distribute modified versions, and to use it for any purpose is
+granted, subject to the following restrictions and understandings.
+
+1.  Any copy made of this software must include this copyright notice
+in full.
+
+2.  I have made no warranty or representation that the operation of
+this software will be error-free, and I am under no obligation to
+provide any services, by way of maintenance, update, or otherwise.
+
+3.  In conjunction with products arising from the use of this
+material, there shall be no use of my name in any advertising,
+promotional, or sales literature without prior written consent in
+each case.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.org
+++ b/README.org
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 - 2021 Arthur A. Gleckler <srfi@speechcode.com>
+#
+# SPDX-License-Identifier: MIT
+
 * SRFI 151: Bitwise Operations
 
 ** by John Cowan

--- a/index.html
+++ b/index.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2015 - 2021 Arthur A. Gleckler <srfi@speechcode.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 <!DOCTYPE html>
 <html>
   <head>

--- a/srfi-151.html
+++ b/srfi-151.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016 John Cowan <cowan@ccil.org>
+
+SPDX-License-Identifier: MIT
+-->
+
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
   <head>

--- a/srfi-151/bitwise-33.scm
+++ b/srfi-151/bitwise-33.scm
@@ -1,5 +1,10 @@
 ;;;; bitwise-33 - Olin Shivers's code from SRFI-33 with modified names
 
+;;;
+;;; SPDX-FileCopyrightText: Olin Shivers
+;;;
+;;; SPDX-License-Identifier: LicenseRef-Public-Domain
+;;;
 ;;; Olin Shivers is the sole author of this code, and he has placed it in
 ;;; the public domain.
 ;;; 

--- a/srfi-151/bitwise-60.scm
+++ b/srfi-151/bitwise-60.scm
@@ -1,4 +1,7 @@
 ;;;; bitwise-60 - SRFI-60 procedures without SRFI-33 analogues, renamed
+;;;
+;;; SPDX-License-Identifier: LicenseRef-SLIB
+;;;
 ;;; Copyright (C) 1991, 1993, 2001, 2003, 2005 Aubrey Jaffer
 ;
 ;Permission to copy this software, to modify it, to redistribute it,

--- a/srfi-151/bitwise-core.scm
+++ b/srfi-151/bitwise-core.scm
@@ -1,4 +1,7 @@
 ;;;; bitwise-core, core bitwise operations
+;;;
+;;; SPDX-License-Identifier: LicenseRef-SLIB
+;;;
 ;;; Copyright (C) 1991, 1993, 2001, 2003, 2005 Aubrey Jaffer
 ;;; This implementation of the seven core functions required by SRFI 33
 ;;; (bitwise-not, bitwise-and, bitwise-ior, bitwise-xor, arithmetic-shift,

--- a/srfi-151/bitwise-other.scm
+++ b/srfi-151/bitwise-other.scm
@@ -1,5 +1,7 @@
 ;;;; bitwise-other - functions not from SRFI 33 or SRFI 60
 ;;; Copyright John Cowan 2017
+;;;
+;;; SPDX-License-Identifier: MIT
 
 (define bits->vector
   (case-lambda

--- a/srfi-151/chibi-test.scm
+++ b/srfi-151/chibi-test.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2017 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (import (scheme base) (srfi-151) (chibi test))
 (current-test-verbosity #f)
 (test-group "bitwise"

--- a/srfi-151/chicken-test.scm
+++ b/srfi-151/chicken-test.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2017 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (import (chicken bitwise)) (import srfi-151) (import test)
 (current-test-verbosity #f)
 (test-group "bitwise"

--- a/srfi-151/srfi-151.scm
+++ b/srfi-151/srfi-151.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2017 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ;;;; chicken implementation of SRFI 151
 (module srfi-151 ()
   (import scheme)

--- a/srfi-151/srfi-151.sld
+++ b/srfi-151/srfi-151.sld
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2017 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (define-library (srfi-151) 
   (import (scheme base))
   (import (scheme case-lambda))


### PR DESCRIPTION
Currently 'reuse lint' fails with:

```
# BAD LICENSES

'SLIB' found in:
* LICENSES/SLIB.txt
* srfi-151/bitwise-60.scm
* srfi-151/bitwise-core.scm
```
Because SPDX and REUSE doesn't yet know about the SLIB license.  I intend to fix this, starting with this PR: https://github.com/spdx/license-list-XML/pull/2268